### PR TITLE
Fix viewer cache clear bug

### DIFF
--- a/options.js
+++ b/options.js
@@ -4,8 +4,12 @@ clearPhotos.onclick = function(element) {
     chrome.storage.local.set({photoURIs: []}, function(data) {
             console.log("Clear photos database");
             chrome.tabs.query({title: 'Looking Glass Viewer for Facebook 3D Photos'}, function(tabs) {
-                var windows = chrome.extension.getViews({tabId: tabs[0].id});
-                windows[0].updatePhotos([]);
+                if(tabs.length > 0) {
+                    var windows = chrome.extension.getViews({tabId: tabs[0].id});
+                    if(windows[0] && windows[0].viewer) {
+                        windows[0].viewer.updatePhotos([]);
+                    }
+                }
             });
         }
     );


### PR DESCRIPTION
## Summary
- fix options page clearing by calling `viewer.updatePhotos` safely

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6854ba9bea1c83268f7c54a190fc8dfb