### PR TITLE
Fix viewer update call in options

### DIFF
--- a/options.js
+++ b/options.js
@@ -5,7 +5,7 @@ clearPhotos.onclick = function(element) {
             console.log("Clear photos database");
             chrome.tabs.query({title: 'Looking Glass Viewer for Facebook 3D Photos'}, function(tabs) {
                 var windows = chrome.extension.getViews({tabId: tabs[0].id});
-                windows[0].updatePhotos([]);
+                windows[0].viewer.updatePhotos([]);
             });
         }
     );


### PR DESCRIPTION
## Summary
- ensure options page clears the viewer's cached photos via the viewer object

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854bbaed4c08326a5ccf45a2b768887