### PR TITLE
Add jest unit tests for photo navigation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  testEnvironment: 'node',
+  transform: {},
+  moduleNameMapper: {
+    '^./deps/three/examples/jsm/loaders/GLTFLoader.js$': '<rootDir>/tests/__mocks__/GLTFLoader.js',
+    '^./deps/holoplay/holoplay.module.js$': '<rootDir>/tests/__mocks__/holoplay.module.js'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -10,11 +10,16 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-copy-deps": "^1.4.0",
     "grunt-curl": "^2.5.0",
-    "grunt-zip": "^0.18.1"
+    "grunt-zip": "^0.18.1",
+    "jest": "^30.0.2"
   },
   "dependencies": {
     "holoplay": "^1.0.3",
     "holoplay-gamepad": "^1.0.1",
     "three": "^0.101.1"
-  }
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "type": "module"
 }

--- a/tests/LKGPhotoViewer.test.js
+++ b/tests/LKGPhotoViewer.test.js
@@ -1,0 +1,26 @@
+import { jest } from "@jest/globals";
+import LKGPhotoViewer from "../lkg-viewer/js/LKGPhotoViewer.js";
+
+describe('LKGPhotoViewer photo navigation', () => {
+  test('nextPhoto wraps to first photo', () => {
+    const viewer = Object.create(LKGPhotoViewer.prototype);
+    viewer.photos = ['1', '2', '3'];
+    viewer.selectedPhoto = 2;
+    viewer.reloadPhoto = jest.fn();
+
+    viewer.nextPhoto();
+
+    expect(viewer.selectedPhoto).toBe(0);
+  });
+
+  test('previousPhoto wraps to last photo', () => {
+    const viewer = Object.create(LKGPhotoViewer.prototype);
+    viewer.photos = ['1', '2', '3'];
+    viewer.selectedPhoto = 0;
+    viewer.reloadPhoto = jest.fn();
+
+    viewer.previousPhoto();
+
+    expect(viewer.selectedPhoto).toBe(2);
+  });
+});

--- a/tests/__mocks__/GLTFLoader.js
+++ b/tests/__mocks__/GLTFLoader.js
@@ -1,0 +1,1 @@
+export class GLTFLoader {}

--- a/tests/__mocks__/holoplay.module.js
+++ b/tests/__mocks__/holoplay.module.js
@@ -1,0 +1,2 @@
+export class Camera {}
+export class Renderer {}


### PR DESCRIPTION
## Summary
- add Jest configuration and mocks
- add unit tests for navigating photos
- support ESM tests via `node --experimental-vm-modules`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854bbb3e70883268c94a7174495e034