### PR TITLE
Automate version bump for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable
+      - name: Bump patch version
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          npm version patch --no-git-tag-version
+          git add manifest.json package.json
+          git commit -m "chore: bump version to $(node -p \"require('./package.json').version\") [skip ci]"
+          git tag v$(node -p "require('./package.json').version")
+          git push --follow-tags
       - name: Package extension
         run: npx grunt --gruntfile Gruntfile.cjs package
       - name: Publish to Chrome Web Store

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,19 @@
   "name": "3D Photo Viewer for Looking Glass",
   "version": "2.0.1",
   "description": "3D Photo Viewer for the Looking Glass holographic display.",
-  "permissions": ["tabs", "webRequest","declarativeContent","storage", "system.display", "*://*.facebook.com/",
-    "*://*.fbcdn.net/"],
+  "permissions": [
+    "tabs",
+    "webRequest",
+    "declarativeContent",
+    "storage",
+    "system.display",
+    "*://*.facebook.com/",
+    "*://*.fbcdn.net/"
+  ],
   "background": {
-    "scripts": ["background.js"],
+    "scripts": [
+      "background.js"
+    ],
     "persistent": true
   },
   "page_action": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "three": "^0.137.0"
   },
   "scripts": {
-    "test": "node test/quiltExport.test.js && node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node test/quiltExport.test.js && node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "postversion": "node scripts/sync-manifest-version.cjs && git add manifest.json"
   },
   "type": "module"
 }

--- a/scripts/sync-manifest-version.cjs
+++ b/scripts/sync-manifest-version.cjs
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const manifestPath = 'manifest.json';
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+manifest.version = pkg.version;
+fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`Updated manifest version to ${manifest.version}`);


### PR DESCRIPTION
## Summary
- sync manifest.json with package.json on version bumps
- add postversion npm script to run the sync
- automate patch bumps in the deploy workflow

## Testing
- `yarn install --immutable`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6854e4c64a0c832683dd72edafed831b