### PR TITLE
Update CI to deploy on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [master, main]
+    tags:
+      - 'v*'
   pull_request:
   workflow_dispatch:
 
@@ -27,9 +29,33 @@ jobs:
           name: chrome-extension
           path: dist/*.zip
 
-  deploy:
+  tag_release:
     needs: build
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Approve release
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.token }}
+          approvers: ${{ github.repository_owner }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Bump patch version and tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          npm version patch -m "chore: release %s [skip ci]"
+          git push --follow-tags
+
+  deploy:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,15 +65,11 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable
-      - name: Bump patch version
+      - name: Set version from tag
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          npm version patch --no-git-tag-version
-          git add manifest.json package.json
-          git commit -m "chore: bump version to $(node -p \"require('./package.json').version\") [skip ci]"
-          git tag v$(node -p "require('./package.json').version")
-          git push --follow-tags
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          npm version "$VERSION" --no-git-tag-version
       - name: Package extension
         run: npx grunt --gruntfile Gruntfile.cjs package
       - name: Publish to Chrome Web Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,17 +23,20 @@ npm test
 ## CI pipeline
 
 The repository includes a GitHub Actions workflow that automatically runs on
-pull requests and pushes to the `main` or `master` branches. The pipeline:
+pull requests, pushes to the `main` or `master` branches, and when a new version
+tag is pushed. The pipeline:
 
 1. Checks out the repository and installs Node.js 20 with cached Yarn modules.
 2. Installs project dependencies using `yarn install --immutable`.
 3. Executes `npm test` to run the Jest test suite.
 4. Builds a zip archive of the Chrome extension using Grunt.
 5. Uploads the archive as a workflow artifact.
+6. On the `main` or `master` branch a manual approval step can be used to bump
+   the patch version and create a tag for the next release.
 
-When running on the `main` or `master` branch the workflow will also attempt to
-publish the packaged extension to the Chrome Web Store. Publishing requires the
-following secrets to be defined in the repository or organization settings:
+When a tag matching `v*` is pushed the workflow will attempt to publish the
+packaged extension to the Chrome Web Store. Publishing requires the following
+secrets to be defined in the repository or organization settings:
 
 - `CHROME_EXTENSION_ID`
 - `CHROME_CLIENT_ID`


### PR DESCRIPTION
## Summary
- adjust workflow trigger to run on tag pushes
- deploy only for tags and set version from tag
- add manual step to cut next release tag on default branch
- update docs to explain tag-based deployment and manual tag step

## Testing
- `yarn install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854e69589f08326affc95ef7243dc76