### PR TITLE
Fix yarn install in tag release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '20'
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --frozen-lockfile
       - name: Run tests
         run: npm test
       - name: Package extension
@@ -41,7 +41,7 @@ jobs:
           node-version: '20'
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --frozen-lockfile
       - name: Bump patch version and tag
         run: |
           git config user.name "GitHub Actions"
@@ -60,7 +60,7 @@ jobs:
           node-version: '20'
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --frozen-lockfile
       - name: Set version from tag
         run: |
           VERSION=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
## Summary
- avoid yarn lockfile changes during CI by using `yarn install --frozen-lockfile`
- update all jobs to use the frozen lockfile option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f027b6cc8326ad5959008abfb771