### PR TITLE
Fix release workflow to deploy without new tag job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment: production
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -43,29 +45,32 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Bump patch version and tag
+        id: bump
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          npm version patch -m "chore: release %s [skip ci]"
+          NEW_TAG=$(npm version patch -m "chore: release %s [skip ci]")
+          echo "tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
           git push --follow-tags
 
   deploy:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: tag_release
+    if: needs.tag_release.outputs.tag != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout release tag
+        run: |
+          git fetch --tags
+          git checkout ${{ needs.tag_release.outputs.tag }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Set version from tag
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          VERSION=${VERSION#v}
-          npm version "$VERSION" --no-git-tag-version
       - name: Package extension
         run: npx grunt --gruntfile Gruntfile.cjs package
       - name: Publish to Chrome Web Store


### PR DESCRIPTION
## Summary
- keep `[skip ci]` for release bump and capture new tag
- checkout the newly created tag in deploy step
- run deploy as part of the same workflow chain

## Testing
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_6854fe6963d8832699762fe4b061bb30