### PR TITLE
Fix tag_release output parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          NEW_TAG=$(npm version patch -m "chore: release %s [skip ci]")
+          npm version patch -m "chore: release %s [skip ci]"
+          NEW_TAG="v$(node -p "require('./package.json').version")"
           echo "tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
           git push --follow-tags
 


### PR DESCRIPTION
## Summary
- handle npm output in tag_release job

## Testing
- `npm install` *(fails: EINTEGRITY while downloading uuid)*

------
https://chatgpt.com/codex/tasks/task_e_6855005015b4832699ea962bbde98822