### PR TITLE
Fix version bump syncs manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "3D Photo Viewer for Looking Glass",
-  "version": "2.0.2",
+  "version": "2.0.5",
   "description": "3D Photo Viewer for the Looking Glass holographic display.",
   "permissions": [
     "tabs",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "test": "node test/quiltExport.test.js && node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "postversion": "node scripts/sync-manifest-version.cjs && git add manifest.json"
+    "version": "node scripts/sync-manifest-version.cjs && git add manifest.json"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- keep manifest version in sync with package.json when running `npm version`

## Testing
- `yarn install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550269a32883268a3fc1bfc9e7c30e