### PR TITLE
Refactor CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +21,26 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Run tests
         run: npm test
+        env:
+          JEST_JUNIT_OUTPUT_FILE: ./test-results/junit.xml
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/junit.xml
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Package extension
         run: npx grunt --gruntfile Gruntfile.cjs package
       - name: Upload packaged extension

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "grunt-copy-deps": "^1.4.0",
     "grunt-curl": "^2.5.0",
     "grunt-zip": "^0.18.1",
-    "jest": "^30.0.2"
+    "jest": "^30.0.2",
+    "jest-junit": "^16.0.0"
   },
   "dependencies": {
     "holoplay": "^1.0.3",
@@ -20,7 +21,7 @@
     "three": "^0.137.0"
   },
   "scripts": {
-    "test": "node test/quiltExport.test.js && node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "node test/quiltExport.test.js && node --experimental-vm-modules node_modules/jest/bin/jest.js --reporters=default --reporters=jest-junit",
     "version": "node scripts/sync-manifest-version.cjs && git add manifest.json"
   },
   "type": "module"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3375,3 +3375,12 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+jest-junit@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-16.0.0.tgz#d838e8c561cf9fdd7eb54f63020777eee4136785"
+  integrity sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"


### PR DESCRIPTION
## Summary
- simplify test script by adding junit reporter to `npm test`
- run the CI job with `npm test` and still upload JUnit XML results

## Testing
- `npm test` *(fails: Cannot find module '/workspace/3DPhotoViewer/node_modules/jest/bin/jest.js')*
- `yarn install --immutable` *(fails: lockfile would have been modified)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685506895a3c8326a53b362fae167ae9