### PR TITLE
Add Puppeteer integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Install Puppeteer
+        run: yarn add --dev puppeteer
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
+      - name: Run integration tests
+        uses: mujo-code/puppeteer-headful@v16.6.0
+        with:
+          args: node test/integration.test.js
       - name: Run tests
         run: npm test
         env:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "grunt-curl": "^2.5.0",
     "grunt-zip": "^0.18.1",
     "jest": "^30.0.2",
-    "jest-junit": "^16.0.0"
+    "jest-junit": "^16.0.0",
+    "puppeteer": "10.4.0"
   },
   "dependencies": {
     "holoplay": "^1.0.3",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,27 @@
+import puppeteer from 'puppeteer';
+
+async function run() {
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox'],
+    executablePath: process.env.PUPPETEER_EXEC_PATH,
+    headless: false,
+  });
+  try {
+    const page = await browser.newPage();
+    const url = 'file://' + process.cwd() + '/lkg-viewer/index.html';
+    await page.goto(url);
+    await page.waitForSelector('canvas');
+    const viewerExists = await page.evaluate(() => typeof window.viewer !== 'undefined');
+    if (!viewerExists) {
+      throw new Error('viewer global not found');
+    }
+    console.log('Integration tests passed');
+  } finally {
+    await browser.close();
+  }
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Puppeteer-based integration test
- install Puppeteer on CI and run the integration test in a headful browser

## Testing
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_685700a7772083269267cc4ed3940638